### PR TITLE
Add quit keyboard shortcut and menu item

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -13,6 +13,7 @@
 
 #include <QProcess>
 #include <QMessageBox>
+#include <QShortcut>
 #include <iostream>
 
 using namespace std;
@@ -33,6 +34,9 @@ MainWindow::MainWindow(QWidget *parent) :
     // Set Item Model
     itemModel = new QStandardItemModel(this);
     ui->tableView->setModel(itemModel);
+
+    QShortcut *shortcutQuit = new QShortcut(QKeySequence("Ctrl+Q"),this);
+    connect(shortcutQuit, SIGNAL(activated()), ui->actionQuit, SLOT(trigger()));
 
 }
 
@@ -117,6 +121,12 @@ void MainWindow::on_actionLoadBoots_triggered()
 {
     // Load system boots
     this->on_listBootsButton_clicked();
+}
+
+void MainWindow::on_actionQuit_triggered()
+{
+    // Quit
+    this->close();
 }
 
 void MainWindow::on_tableView_doubleClicked(const QModelIndex &index)

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -34,6 +34,8 @@ private slots:
 
     void on_actionLoadBoots_triggered();
 
+    void on_actionQuit_triggered();
+
     void on_tableView_doubleClicked(const QModelIndex &index);
 
     void on_actionShowCompleteJournal_triggered();

--- a/ui/mainwindow.ui
+++ b/ui/mainwindow.ui
@@ -140,6 +140,8 @@
     <addaction name="actionLoadBoots"/>
     <addaction name="actionShowCompleteJournal"/>
     <addaction name="actionSizeOfTheJournalOnTheDisk"/>
+    <addaction name="separator"/>
+    <addaction name="actionQuit"/>
    </widget>
    <widget class="QMenu" name="menuOK">
     <property name="title">
@@ -177,6 +179,11 @@
   <action name="actionSizeOfTheJournalOnTheDisk">
    <property name="text">
     <string>Size &amp;of the journal on the disk</string>
+   </property>
+  </action>
+  <action name="actionQuit">
+   <property name="text">
+    <string>&amp;Quit</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
I believe these features are important for users of tiling window managers, which often do not have any window decoration (thus no close button). The <kbd>CTRL</kbd>+<kbd>Q</kbd> shortcut is also a very common shortcut to exit a program.