### PR TITLE
QJournalctl win32 x64 port.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ### A Qt-based Graphical User Interface for systemd's journalctl command 
 
 
-#### About QJournalctl 
+## About QJournalctl 
 systemd provides `journalctl` to display and analyze its journal. Think of
 the journal as a giant log file for the whole system. Different programs
 (like e.g. different software/services on your system, but also the kernel) write their log entries into systemd's
@@ -13,13 +13,23 @@ quickly for specific reports or errors.
 
 Maybe you want to checkout the [Changelog](https://github.com/pentix/qjournalctl/blob/master/CHANGELOG.md).
 
-#### Build Dependencies
+
+## QJournalctl for Linux
+
+### ArchLinux and Manjaro
+QJournalctl is available in the community repository for the **Archlinux** and **Manjaro** Distributions:
+
+```bash
+sudo pacman -S qjournalctl
+```
+For other distributions, it is required to build it from sources.
+
+### Build Dependencies
 * Make sure your compiler supports (at least) C++11 (E.g. `g++` ≥ 4.8.1, `clang` ≥ 3.3)
 * QJournalctl relies on Qt5, please ensure to have the Qt5 development libaries (E.g. `qtbase5-dev` for Debian/Ubuntu) installed, when compiling!
 * To access remote hosts QJournalctl heavily relies on `libssh` ≥ [0.8.7](https://www.libssh.org/files/0.8/)
 
-
-#### Build Dependencies for Debian, Ubuntu, et al.
+### Build Dependencies (Old Distros) 
 Your distribution's supplied version of `libssh` might be too old for a successful build. You need
 to build and install libssh yourself (< 2 minutes!)
 
@@ -36,15 +46,48 @@ to build and install libssh yourself (< 2 minutes!)
 `cd ../..`
 
 
-#### Building QJournalctl
+### Building QJournalctl
 1. Download the source code and extract it
 2. Run `./autogen.sh`
 3. Run `make -j5` to compile qjournalctl
 
 
-#### ArchLinux and Manjaro
-QJournalctl is available in the community repository:
-`sudo pacman -S qjournalctl`
+## QJournalctl for Windows
+
+### Build Dependencies
+
+To buuild QJournalctl for Windows, it is needed
+- Visual Studio 2019 Community 
+   - MSVC C++ Build Tools for x64/x86 >= `v141`
+- Qt Open-Source >= `5.14.1`
+- vcpkg >= `2020.01` (https://github.com/microsoft/vcpkg)
+   - *Note* Install following the *Install the QJournalctl Dependencies* instructions
+
+### Install the QJournalctl Dependencies
+0. Download the source code and extract it
+1. Download the `vcpkg` tool in the same folder where the QJournalctl repository is cloned
+2. Get the `libssh` dependencies for the target needed:
+```
+vcpkg install libssh:x64-windows
+```
+
+Now, the `libssh` binaries as well as its dependencies can be found at `<repository_root>/vcpkg/packages/`
+
+### Building QJournalctl
+Considering that the *Install the QJournalctl Dependencies* steps are already performed
+0. Adjust the `QTDIR` variable which points to your `msvc` tooling folder at your Qt Installation path in the `autogen_and_build.bat`:
+```
+set QTDIR=C:\Qt\Qt5.14.1\5.14.1\msvc2017_64
+```
+1. Open a new *Visual Studio Developer Command prompt by running 
+```
+<visual_studio_install_path>\2019\Community\VC\Auxiliary\Build\vcvarsall.bat x64
+```
+2. Run `autogen_and_build.bat`
+
+The application can be found at `release/` folder.
+
+**Note** The process can be repeated by modifying the `autogen_and_build.bat` script in the commented sections
 
 
 #### Screenshots

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
-# QJournalctl v0.6.2 [![Build Status](https://travis-ci.org/pentix/qjournalctl.svg?branch=master)](https://travis-ci.org/pentix/qjournalctl)
+# QJournalctl v0.6.2 
+
+[![Build Status](https://travis-ci.org/pentix/qjournalctl.svg?branch=master)](https://travis-ci.org/pentix/qjournalctl)
+[![Build Status](https://ci.appveyor.com/api/projects/status/32r7s2skrgm9ubva?svg=true)](https://ci.appveyor.com/api/projects/status/32r7s2skrgm9ubva?svg=true)
+
+
 ### A Qt-based Graphical User Interface for systemd's journalctl command 
 
 

--- a/README.md
+++ b/README.md
@@ -79,11 +79,16 @@ Considering that the *Install the QJournalctl Dependencies* steps are already pe
 ```
 set QTDIR=C:\Qt\Qt5.14.1\5.14.1\msvc2017_64
 ```
-1. Open a new *Visual Studio Developer Command prompt by running 
+1. Adjust the `VCPKG_FOLDER` variable pointing to the directory where the repository is downloaded
+```
+qmake qjournalctl.pro CONFIG+=release CONFIG+=x86_64 VCPKG_FOLDER=.
+```
+
+2. Open a new *Visual Studio Developer Command prompt by running 
 ```
 <visual_studio_install_path>\2019\Community\VC\Auxiliary\Build\vcvarsall.bat x64
 ```
-2. Run `autogen_and_build.bat`
+3. Run `autogen_and_build.bat`
 
 The application can be found at `release/` folder.
 

--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ to build and install libssh yourself (< 2 minutes!)
 ### Build Dependencies
 
 To buuild QJournalctl for Windows, it is needed
-- Visual Studio 2019 Community 
+- Visual Studio 2017 Community 
    - MSVC C++ Build Tools for x64/x86 >= `v141`
-- Qt Open-Source >= `5.14.1`
+- Qt Open-Source >= `5.13.2`
 - vcpkg >= `2020.01` (https://github.com/microsoft/vcpkg)
    - *Note* Install following the *Install the QJournalctl Dependencies* instructions
 
@@ -97,7 +97,7 @@ qmake qjournalctl.pro CONFIG+=release CONFIG+=x86_64 VCPKG_FOLDER=.
 
 The application can be found at `release/` folder.
 
-**Note** The process can be repeated by modifying the `autogen_and_build.bat` script in the commented sections
+**Note** The process can be repeated for the `x86` platform by modifying the `autogen_and_build.bat` script in the commented sections
 
 
 #### Screenshots

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ qmake qjournalctl.pro CONFIG+=release CONFIG+=x86_64 VCPKG_FOLDER=.
 
 2. Open a new *Visual Studio Developer Command prompt by running 
 ```
-<visual_studio_install_path>\2019\Community\VC\Auxiliary\Build\vcvarsall.bat x64
+<visual_studio_install_path>\2017\Community\VC\Auxiliary\Build\vcvarsall.bat x64
 ```
 3. Run `autogen_and_build.bat`
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,9 +29,6 @@ install:
   - echo This is batch
   - set QTDIR=C:\Qt\5.14.1\msvc2017_64
   - set PATH=%QTDIR%\bin;%PATH%
-  - dir "c:/tools/vcpkg/"
-  - dir "c:/tools/vcpkg/packages/"
-  - dir "c:/tools/vcpkg/packages/libssh_x64-windows/include"
 
 # to run your custom scripts instead of automatic MSBuild
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,12 +29,6 @@ install:
   - echo This is batch
   - cmd  call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
 
-# build platform, i.e. x86, x64, Any CPU. This setting is optional.
-platform: x64
-
-# build Configuration, i.e. Debug, Release, etc.
-configuration: Release
-
 # to run your custom scripts instead of automatic MSBuild
 build_script: autogen_and_build.bat
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,9 +29,9 @@ install:
   - echo This is batch
   - set QTDIR=C:\Qt\5.14.1\msvc2017_64
   - set PATH=%QTDIR%\bin;%PATH%
-  - dir c:/tools/vcpkg/
-  - dir c:/tools/vcpkg/packages/
-  - dir c:/tools/vcpkg/packages/libssh_x64-windows/include
+  - dir "c:/tools/vcpkg/"
+  - dir "c:/tools/vcpkg/packages/"
+  - dir "c:/tools/vcpkg/packages/libssh_x64-windows/include"
 
 # to run your custom scripts instead of automatic MSBuild
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,8 @@ install:
   - cmd  call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
 
 # to run your custom scripts instead of automatic MSBuild
-build_script: autogen_and_build.bat
+build_script:
+  - cmd autogen_and_build.bat
 
 #---------------------------------#
 #      artifacts configuration    #

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,46 @@
+#---------------------------------#
+#      general configuration      #
+#---------------------------------#
+
+# version format
+version: 1.0.{build}
+
+# branches to build
+#branches:
+  # whitelist
+  # only:
+  #  - master
+  #  - production
+
+# Build worker image (VM template)
+image: Visual Studio 2017
+
+# build cache to preserve files/folders between builds
+cache: c:\tools\vcpkg\installed\
+
+# scripts that run after cloning repository
+install:
+  # by default, all script lines are interpreted as batch
+  - cd C:\Tools\vcpkg
+  - git pull
+  - .\bootstrap-vcpkg.bat
+  - cd %APPVEYOR_BUILD_FOLDER%
+  - vcpkg install libssh:x64-windows
+  - echo This is batch
+  - cmd  call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
+
+# build platform, i.e. x86, x64, Any CPU. This setting is optional.
+platform: x64
+
+# build Configuration, i.e. Debug, Release, etc.
+configuration: Release
+
+# to run your custom scripts instead of automatic MSBuild
+build_script: autogen_and_build.bat
+
+#---------------------------------#
+#      artifacts configuration    #
+#---------------------------------#
+artifacts:
+  # pushing entire folder as a zip archive
+  - path: release

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,7 @@ install:
 
 # to run your custom scripts instead of automatic MSBuild
 build_script:
-  - cmd autogen_and_build.bat
+  - autogen_and_build.bat
 
 #---------------------------------#
 #      artifacts configuration    #

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,6 +29,9 @@ install:
   - echo This is batch
   - set QTDIR=C:\Qt\5.14.1\msvc2017_64
   - set PATH=%QTDIR%\bin;%PATH%
+  - dir c:/tools/vcpkg/
+  - dir c:/tools/vcpkg/packages/
+  - dir c:/tools/vcpkg/packages/libssh_x64-windows/include
 
 # to run your custom scripts instead of automatic MSBuild
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ cache: c:\tools\vcpkg\installed\
 
 # scripts that run after cloning repository
 install:
-  - call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"
+  - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
   - cd C:\Tools\vcpkg
   - git pull
   - .\bootstrap-vcpkg.bat

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,6 +27,8 @@ install:
   - cd %APPVEYOR_BUILD_FOLDER%
   - vcpkg install libssh:x64-windows
   - echo This is batch
+  - set QTDIR=C:\Qt\5.14.1\msvc2017_64
+  - set PATH=%QTDIR%\bin;%PATH%
 
 # to run your custom scripts instead of automatic MSBuild
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,14 +20,13 @@ cache: c:\tools\vcpkg\installed\
 
 # scripts that run after cloning repository
 install:
-  # by default, all script lines are interpreted as batch
+  - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
   - cd C:\Tools\vcpkg
   - git pull
   - .\bootstrap-vcpkg.bat
   - cd %APPVEYOR_BUILD_FOLDER%
   - vcpkg install libssh:x64-windows
   - echo This is batch
-  - cmd  call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
 
 # to run your custom scripts instead of automatic MSBuild
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ version: 1.0.{build}
   #  - production
 
 # Build worker image (VM template)
-image: Visual Studio 2019
+image: Visual Studio 2017
 
 # build cache to preserve files/folders between builds
 cache: c:\tools\vcpkg\installed\
@@ -27,7 +27,7 @@ install:
   - cd %APPVEYOR_BUILD_FOLDER%
   - vcpkg install libssh:x64-windows
   - echo This is batch
-  - set QTDIR=C:\Qt\5.14.1\msvc2017_64
+  - set QTDIR=C:\Qt\5.13.2\msvc2017_64
   - set PATH=%QTDIR%\bin;%PATH%
 
 # to run your custom scripts instead of automatic MSBuild

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,14 +13,14 @@ version: 1.0.{build}
   #  - production
 
 # Build worker image (VM template)
-image: Visual Studio 2017
+image: Visual Studio 2019
 
 # build cache to preserve files/folders between builds
 cache: c:\tools\vcpkg\installed\
 
 # scripts that run after cloning repository
 install:
-  - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
+  - call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"
   - cd C:\Tools\vcpkg
   - git pull
   - .\bootstrap-vcpkg.bat

--- a/autogen_and_build.bat
+++ b/autogen_and_build.bat
@@ -26,8 +26,8 @@ rem copy %VCPKG_INSTALL_FOLDER%\vcpkg\packages\libssh_x86-windows\bin\ssh.dll re
 rem copy %VCPKG_INSTALL_FOLDER%\vcpkg\packages\pthreads_x86-windows\bin\ssh.dll release\pthreadVC3.dll
 
 rem 64 bits
-copy %VCPKG_INSTALL_FOLDER%\vcpkg\packages\libssh_x64-windows\bin\ssh.dll release\ssh.dll
-copy %VCPKG_INSTALL_FOLDER%\vcpkg\packages\pthreads_x64-windows\bin\pthreadVC3.dll release\pthreadVC3.dll
+copy %VCPKG_INSTALL_FOLDER%\packages\libssh_x64-windows\bin\ssh.dll release\ssh.dll
+copy %VCPKG_INSTALL_FOLDER%\packages\pthreads_x64-windows\bin\pthreadVC3.dll release\pthreadVC3.dll
 
 del release\*.obj
 del release\*.cpp

--- a/autogen_and_build.bat
+++ b/autogen_and_build.bat
@@ -26,8 +26,8 @@ rem copy %VCPKG_INSTALL_FOLDER%\vcpkg\packages\libssh_x86-windows\bin\ssh.dll re
 rem copy %VCPKG_INSTALL_FOLDER%\vcpkg\packages\pthreads_x86-windows\bin\ssh.dll release\pthreadVC3.dll
 
 rem 64 bits
-copy %VCPKG_INSTALL_FOLDER%\packages\libssh_x64-windows\bin\ssh.dll release\ssh.dll
-copy %VCPKG_INSTALL_FOLDER%\packages\pthreads_x64-windows\bin\pthreadVC3.dll release\pthreadVC3.dll
+copy %VCPKG_INSTALL_FOLDER%\installed\x64-windows\bin\ssh.dll release\ssh.dll
+copy %VCPKG_INSTALL_FOLDER%\installed\x64-windows\bin\pthreadVC3.dll release\pthreadVC3.dll
 
 del release\*.obj
 del release\*.cpp

--- a/autogen_and_build.bat
+++ b/autogen_and_build.bat
@@ -5,10 +5,8 @@ set OLD_PATH=%PATH%
 rem "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" x86
 rem set QTDIR=C:\Qt\Qt5.14.1\5.14.1\msvc2017
 rem "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" x64
-set QTDIR=C:\Qt\5.14.1\msvc2017_64
+set QTDIR=C:\Qt\5.13.2\msvc2017_64
 set PATH=%QTDIR%\bin;%PATH%
-echo %PATH%
-set QMAKE_BIN=qmake
 set QT_SELECT=qt5
 set QMAKESPEC=win32-msvc
 set VCPKG_INSTALL_FOLDER=c:\tools\vcpkg

--- a/autogen_and_build.bat
+++ b/autogen_and_build.bat
@@ -5,7 +5,7 @@ set OLD_PATH=%PATH%
 rem "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" x86
 rem set QTDIR=C:\Qt\Qt5.14.1\5.14.1\msvc2017
 rem "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" x64
-set QTDIR=C:\Qt\Qt5.14.1\5.14.1\msvc2017_64
+set QTDIR=C:\Qt\5.14.1\msvc2017_64
 set PATH=%QTDIR%\bin;%PATH%
 set QMAKE_BIN=qmake
 set QT_SELECT=qt5

--- a/autogen_and_build.bat
+++ b/autogen_and_build.bat
@@ -33,4 +33,3 @@ del release\*.cpp
 
 REM Restore the new path
 set PATH=%OLD_PATH%
-pause

--- a/autogen_and_build.bat
+++ b/autogen_and_build.bat
@@ -1,0 +1,36 @@
+REM ---------------------------------------------------------------------
+REM Batch file to make all Makefiles or all Visual Studio project files
+REM ---------------------------------------------------------------------
+set OLD_PATH=%PATH%
+rem "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" x86
+rem set QTDIR=C:\Qt\Qt5.14.1\5.14.1\msvc2017
+rem "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" x64
+set QTDIR=C:\Qt\Qt5.14.1\5.14.1\msvc2017_64
+set PATH=%QTDIR%\bin;%PATH%
+set QMAKE_BIN=qmake
+set QT_SELECT=qt5
+set QMAKESPEC=win32-msvc
+
+rem 32 bits
+rem qmake qjournalctl.pro CONFIG+=release
+
+rem 64 bits
+qmake qjournalctl.pro CONFIG+=release CONFIG+=x86_64
+
+nmake
+windeployqt release/qjournalctl.exe
+
+rem 32 bits
+rem copy vcpkg\packages\libssh_x86-windows\bin\ssh.dll release\ssh.dll
+rem copy vcpkg\packages\pthreads_x86-windows\bin\ssh.dll release\pthreadVC3.dll
+
+rem 64 bits
+copy vcpkg\packages\libssh_x64-windows\bin\ssh.dll release\ssh.dll
+copy vcpkg\packages\pthreads_x64-windows\bin\pthreadVC3.dll release\pthreadVC3.dll
+
+del release\*.obj
+del release\*.cpp
+
+REM Restore the new path
+set PATH=%OLD_PATH%
+pause

--- a/autogen_and_build.bat
+++ b/autogen_and_build.bat
@@ -10,23 +10,23 @@ set PATH=%QTDIR%\bin;%PATH%
 set QMAKE_BIN=qmake
 set QT_SELECT=qt5
 set QMAKESPEC=win32-msvc
-
+set VCPKG_INSTALL_FOLDER=c:\tools\vcpkg
 rem 32 bits
-rem qmake qjournalctl.pro CONFIG+=release
+rem qmake qjournalctl.pro CONFIG+=release VCPKG_FOLDER=.
 
 rem 64 bits
-qmake qjournalctl.pro CONFIG+=release CONFIG+=x86_64
+qmake qjournalctl.pro CONFIG+=release CONFIG+=x86_64 VCPKG_FOLDER=%VCPKG_INSTALL_FOLDER%
 
 nmake
 windeployqt release/qjournalctl.exe
 
 rem 32 bits
-rem copy vcpkg\packages\libssh_x86-windows\bin\ssh.dll release\ssh.dll
-rem copy vcpkg\packages\pthreads_x86-windows\bin\ssh.dll release\pthreadVC3.dll
+rem copy %VCPKG_INSTALL_FOLDER%\vcpkg\packages\libssh_x86-windows\bin\ssh.dll release\ssh.dll
+rem copy %VCPKG_INSTALL_FOLDER%\vcpkg\packages\pthreads_x86-windows\bin\ssh.dll release\pthreadVC3.dll
 
 rem 64 bits
-copy vcpkg\packages\libssh_x64-windows\bin\ssh.dll release\ssh.dll
-copy vcpkg\packages\pthreads_x64-windows\bin\pthreadVC3.dll release\pthreadVC3.dll
+copy %VCPKG_INSTALL_FOLDER%\vcpkg\packages\libssh_x64-windows\bin\ssh.dll release\ssh.dll
+copy %VCPKG_INSTALL_FOLDER%\vcpkg\packages\pthreads_x64-windows\bin\pthreadVC3.dll release\pthreadVC3.dll
 
 del release\*.obj
 del release\*.cpp

--- a/autogen_and_build.bat
+++ b/autogen_and_build.bat
@@ -7,6 +7,7 @@ rem set QTDIR=C:\Qt\Qt5.14.1\5.14.1\msvc2017
 rem "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" x64
 set QTDIR=C:\Qt\5.14.1\msvc2017_64
 set PATH=%QTDIR%\bin;%PATH%
+echo %PATH%
 set QMAKE_BIN=qmake
 set QT_SELECT=qt5
 set QMAKESPEC=win32-msvc

--- a/qjournalctl.pro
+++ b/qjournalctl.pro
@@ -71,12 +71,12 @@ INSTALLS += target desktop-file desktop-icon
 win32:
 CONFIG(x86_64) {
 	# 64 bit path
-	INCLUDEPATH += $$VCPKG_FOLDER/packages/libssh_x64-windows/include/
-	LIBS += $$VCPKG_FOLDER/packages/libssh_x64-windows/lib/ssh.lib
+	INCLUDEPATH += $$VCPKG_FOLDER\packages\libssh_x64-windows\include\
+	LIBS += $$VCPKG_FOLDER\packages\libssh_x64-windows\lib\ssh.lib
 } else {
 	# 32 bit path
-	INCLUDEPATH += $$VCPKG_FOLDER/packages/libssh_x86-windows/include/
-	LIBS += $$VCPKG_FOLDER/packages/libssh_x86-windows/lib/ssh.lib
+	INCLUDEPATH += $$VCPKG_FOLDER\packages\libssh_x86-windows\include\
+	LIBS += $$VCPKG_FOLDER\packages\libssh_x86-windows\lib\ssh.lib
 }
 
 unix: CONFIG += link_pkgconfig

--- a/qjournalctl.pro
+++ b/qjournalctl.pro
@@ -71,12 +71,12 @@ INSTALLS += target desktop-file desktop-icon
 win32:
 CONFIG(x86_64) {
 	# 64 bit path
-	INCLUDEPATH += $VCPKG_FOLDER/vcpkg/packages/libssh_x64-windows/include/
-	LIBS += $VCPKG_FOLDER/vcpkg/packages/libssh_x64-windows/lib/ssh.lib
+	INCLUDEPATH += $$VCPKG_FOLDER/vcpkg/packages/libssh_x64-windows/include/
+	LIBS += $$VCPKG_FOLDER/vcpkg/packages/libssh_x64-windows/lib/ssh.lib
 } else {
 	# 32 bit path
-	INCLUDEPATH += $VCPKG_FOLDER/vcpkg/packages/libssh_x86-windows/include/
-	LIBS += VCPKG_FOLDER/vcpkg/packages/libssh_x86-windows/lib/ssh.lib
+	INCLUDEPATH += $$VCPKG_FOLDER/vcpkg/packages/libssh_x86-windows/include/
+	LIBS += $$VCPKG_FOLDER/vcpkg/packages/libssh_x86-windows/lib/ssh.lib
 }
 
 unix: CONFIG += link_pkgconfig

--- a/qjournalctl.pro
+++ b/qjournalctl.pro
@@ -11,7 +11,6 @@ greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 TARGET = qjournalctl
 TEMPLATE = app
 
-
 CONFIG += c++11
 
 SOURCES += src/main.cpp\
@@ -72,12 +71,12 @@ INSTALLS += target desktop-file desktop-icon
 win32:
 CONFIG(x86_64) {
 	# 64 bit path
-	INCLUDEPATH += $$_PRO_FILE_PWD_/vcpkg/packages/libssh_x64-windows/include/
-	LIBS += $$_PRO_FILE_PWD_/vcpkg/packages/libssh_x64-windows/lib/ssh.lib
+	INCLUDEPATH += $VCPKG_FOLDER/vcpkg/packages/libssh_x64-windows/include/
+	LIBS += $VCPKG_FOLDER/vcpkg/packages/libssh_x64-windows/lib/ssh.lib
 } else {
 	# 32 bit path
-	INCLUDEPATH += $$_PRO_FILE_PWD_/vcpkg/packages/libssh_x86-windows/include/
-	LIBS += $$_PRO_FILE_PWD_/vcpkg/packages/libssh_x86-windows/lib/ssh.lib
+	INCLUDEPATH += $VCPKG_FOLDER/vcpkg/packages/libssh_x86-windows/include/
+	LIBS += VCPKG_FOLDER/vcpkg/packages/libssh_x86-windows/lib/ssh.lib
 }
 
 unix: CONFIG += link_pkgconfig

--- a/qjournalctl.pro
+++ b/qjournalctl.pro
@@ -71,11 +71,11 @@ INSTALLS += target desktop-file desktop-icon
 win32:
 CONFIG(x86_64) {
 	# 64 bit path
-	INCLUDEPATH += $$VCPKG_FOLDER\installed\x64-windows\include\
+	INCLUDEPATH += $$VCPKG_FOLDER\installed\x64-windows\include
 	LIBS += $$VCPKG_FOLDER\installed\x64-windows\lib\ssh.lib
 } else {
 	# 32 bit path
-	INCLUDEPATH += $$VCPKG_FOLDER\installed\x86-windows\include\
+	INCLUDEPATH += $$VCPKG_FOLDER\installed\x86-windows\include
 	LIBS += $$VCPKG_FOLDER\installed\x86-windows\lib\ssh.lib
 }
 

--- a/qjournalctl.pro
+++ b/qjournalctl.pro
@@ -71,12 +71,12 @@ INSTALLS += target desktop-file desktop-icon
 win32:
 CONFIG(x86_64) {
 	# 64 bit path
-	INCLUDEPATH += $$VCPKG_FOLDER\packages\libssh_x64-windows\include\
-	LIBS += $$VCPKG_FOLDER\packages\libssh_x64-windows\lib\ssh.lib
+	INCLUDEPATH += $$VCPKG_FOLDER\installed\x64-windows\include\
+	LIBS += $$VCPKG_FOLDER\installed\x64-windows\lib\ssh.lib
 } else {
 	# 32 bit path
-	INCLUDEPATH += $$VCPKG_FOLDER\packages\libssh_x86-windows\include\
-	LIBS += $$VCPKG_FOLDER\packages\libssh_x86-windows\lib\ssh.lib
+	INCLUDEPATH += $$VCPKG_FOLDER\installed\x86-windows\include\
+	LIBS += $$VCPKG_FOLDER\installed\x86-windows\lib\ssh.lib
 }
 
 unix: CONFIG += link_pkgconfig

--- a/qjournalctl.pro
+++ b/qjournalctl.pro
@@ -69,5 +69,16 @@ desktop-icon.files += ui/qjournalctl.png
 
 INSTALLS += target desktop-file desktop-icon
 
+win32:
+CONFIG(x86_64) {
+	# 64 bit path
+	INCLUDEPATH += $$_PRO_FILE_PWD_/vcpkg/packages/libssh_x64-windows/include/
+	LIBS += $$_PRO_FILE_PWD_/vcpkg/packages/libssh_x64-windows/lib/ssh.lib
+} else {
+	# 32 bit path
+	INCLUDEPATH += $$_PRO_FILE_PWD_/vcpkg/packages/libssh_x86-windows/include/
+	LIBS += $$_PRO_FILE_PWD_/vcpkg/packages/libssh_x86-windows/lib/ssh.lib
+}
+
 unix: CONFIG += link_pkgconfig
 unix: PKGCONFIG += libssh

--- a/qjournalctl.pro
+++ b/qjournalctl.pro
@@ -71,12 +71,12 @@ INSTALLS += target desktop-file desktop-icon
 win32:
 CONFIG(x86_64) {
 	# 64 bit path
-	INCLUDEPATH += $$VCPKG_FOLDER/vcpkg/packages/libssh_x64-windows/include/
-	LIBS += $$VCPKG_FOLDER/vcpkg/packages/libssh_x64-windows/lib/ssh.lib
+	INCLUDEPATH += $$VCPKG_FOLDER/packages/libssh_x64-windows/include/
+	LIBS += $$VCPKG_FOLDER/packages/libssh_x64-windows/lib/ssh.lib
 } else {
 	# 32 bit path
-	INCLUDEPATH += $$VCPKG_FOLDER/vcpkg/packages/libssh_x86-windows/include/
-	LIBS += $$VCPKG_FOLDER/vcpkg/packages/libssh_x86-windows/lib/ssh.lib
+	INCLUDEPATH += $$VCPKG_FOLDER/packages/libssh_x86-windows/include/
+	LIBS += $$VCPKG_FOLDER/packages/libssh_x86-windows/lib/ssh.lib
 }
 
 unix: CONFIG += link_pkgconfig


### PR DESCRIPTION
# What? 

This is a contribution which aims to port the `QJournalctl` application to Windows. 

## Details

The major contribution is
- To provide an script and updated configuration to be able to build the application for Windows. 
- To add an `appveyor` configuration to be able to directly obtain the released artifacts from there (deployed artifacts)


 There are some few changes applied to the codebase:
- Migration of the `usleep` to a multi-platform equivalent call
- Minor modification from iniializing an array of size a variable, which is not compliant with the `msvc` build rules. Migrated to safer `malloc` based initialization.

Also to the `README.md`
- Unifying the type of Markdown Titles
- Reordering the `building` chapter 
- Adding an specific Windows chapter

## Remaining tasks

- [ ] To update the Changelog in case of performing a releease with these changes
- [ ] To integrate appveyor to the official repository.