### PR TITLE
Fix: Verify settings not null

### DIFF
--- a/src/connectiondialog.cpp
+++ b/src/connectiondialog.cpp
@@ -182,7 +182,7 @@ void ConnectionDialog::on_authKeyfileRadio_toggled(bool checked)
 void ConnectionDialog::on_cancelButton_clicked()
 {
     // User wants to abort
-    if(!updateOnly){
+    if(!updateOnly && settings){
         *settings = nullptr;
     }
 


### PR DESCRIPTION
What?

Issue: https://github.com/pentix/qjournalctl/issues/52

When the `ConnectionDialog::ConnectionDialog` object is created from the following call

```
    ConnectionDialog dialog(nullptr, nullptr, sshConnectionSerializer, true);
```

The `**settings` object is null (and also `*settings`). Due to this fact, the application crashed when trying to assign an unainitialized value to `nullptr`. 

The solution is based on basically verifying that the variable is initialized prior to setting it to `nullptr`