### PR TITLE
Fix: Saving SSH connection settings on win

### DIFF
--- a/src/sshconnectionsettings.cpp
+++ b/src/sshconnectionsettings.cpp
@@ -14,11 +14,11 @@
 // Needs to be freed afterwards!
 const char *SSHConnectionSettings::qstringToChar(QString s)
 {
-    const int     tmpStrLen = s.toUtf8().size();
-    const char   *tmpStr    = s.toUtf8().constData();
+    const int     tmpStrLen = s.toStdString().size();
           char   *cStr      = (char *)malloc(tmpStrLen+1);
 
-    strncpy(cStr, tmpStr, tmpStrLen+1);
+    strncpy(cStr, s.toStdString().c_str(), tmpStrLen+1);
+    cStr[tmpStrLen] = '\0';
     return cStr;
 }
 


### PR DESCRIPTION
# What?

Issue: https://github.com/pentix/qjournalctl/issues/42

Due to an ill-converted string, the settings were not adequately stored. The contribution modifies
- Uses `toStdString()` instead of `toUTF8()`
- Uses the `c_str()` object instead of the `constData`

The fix has not been tested on Linux