### PR TITLE
Feature: Colorize filtered output

### DIFF
--- a/src/showbootlog.cpp
+++ b/src/showbootlog.cpp
@@ -31,6 +31,8 @@
 #include <QRegularExpression>
 #include <QCompleter>
 #include <QThread>
+#include <QColorDialog>
+#include <QRandomGenerator>
 
 ShowBootLog::ShowBootLog(QWidget *parent) :
     QDialog(parent),
@@ -111,6 +113,7 @@ void ShowBootLog::updateBootLog(bool keepIdentifiers)
         // Reset all previously accepted but also read identifiers   (clear the filter but also do a full reload!)
         this->allIdentifiers.clear();
         this->acceptedIdentifiers.clear();
+        this->acceptedIdentifiersColors.clear();
         identifierFlags = "";
 
         // Also reset the UI parts
@@ -182,8 +185,11 @@ void ShowBootLog::updateBootLog(bool keepIdentifiers)
 
 void ShowBootLog::acceptIdentifier(void){
     this->acceptedIdentifiers.insert(ui->identifiersLineEdit->text());
+    this->acceptedIdentifiersColors.insert(ui->identifiersLineEdit->text(), ui->identifiersLineEdit->palette().color(QPalette::Base));
     updateBootLog(true);
     ui->identifiersLineEdit->clear();
+    QPalette palette(QPalette::Base, Qt::white);
+    ui->identifiersLineEdit->setPalette(palette);
     ui->identifiersLineEdit->setFocus();
 }
 
@@ -191,7 +197,39 @@ void ShowBootLog::acceptIdentifier(void){
 void ShowBootLog::appendToBootLog(QString readString)
 {
     // Append string to the UI and increment byte counter
-    ui->plainTextEdit->appendPlainText(readString);
+    QStringList readStringLines = readString.split("\n");
+    QTextCharFormat defaultFormat, format;
+    QColor defaultColor, color;
+    bool found;
+    for ( const auto& line : readStringLines  )
+    {
+        // Let's find if regex apply for the current line
+        found = false;
+        for(const auto& identifier : this->acceptedIdentifiers){
+            QRegularExpression re(identifier);
+            QRegularExpressionMatch match = re.match(line);
+            found = match.hasMatch();
+            if(found)
+            {
+                color = this->acceptedIdentifiersColors.value(identifier);
+                break;
+            }
+        }
+        if(found)
+        {
+            format = ui->plainTextEdit->currentCharFormat();
+            defaultFormat = format;
+            format.setBackground(QBrush(color));
+            ui->plainTextEdit->setCurrentCharFormat(format);
+            ui->plainTextEdit->appendPlainText(line);
+            ui->plainTextEdit->setCurrentCharFormat(defaultFormat);
+        }
+        else
+        {
+            ui->plainTextEdit->appendPlainText(line);
+        }
+
+    }
     numberOfBytesRead += readString.size();
     ui->plainTextEdit->ensureCursorVisible();
 
@@ -268,7 +306,8 @@ void ShowBootLog::on_filterButton_clicked()
 {
     acceptIdentifier();
     ui->identifiersLineEdit->clear();
-
+    QPalette palette(QPalette::Base, Qt::white);
+    ui->identifiersLineEdit->setPalette(palette);
     updateBootLog(true);
 }
 
@@ -376,7 +415,10 @@ void ShowBootLog::on_clearButton_clicked()
 {
     ui->acceptedIdentifierLabel->setText("");
     ui->identifiersLineEdit->clear();
+    QPalette palette(QPalette::Base, Qt::white);
+    ui->identifiersLineEdit->setPalette(palette);
     this->acceptedIdentifiers.clear();
+    this->acceptedIdentifiersColors.clear();
     updateBootLog(false);
 }
 
@@ -401,3 +443,15 @@ void ShowBootLog::on_exportSelectionButton_clicked()
     writeToExportFile(fileName, selection.toLocal8Bit().data());
 }
 
+void ShowBootLog::on_selectColorButton_clicked()
+{
+    QColor color = QColorDialog::getColor(QColor::fromRgb(QRandomGenerator::global()->generate()), this );
+    QPalette palette;
+    palette.setColor(QPalette::Base, color);
+    if( color.isValid() )
+    {
+      qDebug() << "Color Choosen : " << color.name();
+      ui->identifiersLineEdit->setPalette(palette);
+    }
+
+}

--- a/src/showbootlog.h
+++ b/src/showbootlog.h
@@ -64,7 +64,9 @@ private slots:
 
 	void on_exportSelectionButton_clicked();
 
-	void on_horizontalSlider_valueChanged(int value);
+    void on_horizontalSlider_valueChanged(int value);
+
+    void on_selectColorButton_clicked();
 
 private:
 	void updateBootLog(bool keepIdentifiers=false);
@@ -83,8 +85,9 @@ private:
 	// Internal display variables
 	int numberOfBytesRead=0;
 	QString identifierFlags="";
-	QSet<QString> allIdentifiers;
-	QSet<QString> acceptedIdentifiers;
+    QSet<QString> allIdentifiers;
+    QSet<QString> acceptedIdentifiers;
+    QMap<QString, QColor> acceptedIdentifiersColors;
 
 	void execute_find(QRegExp regexp, QTextDocument::FindFlags findFlags);
 	void execute_find(QString string, QTextDocument::FindFlags findFlags);

--- a/ui/showbootlog.ui
+++ b/ui/showbootlog.ui
@@ -244,6 +244,16 @@
         </widget>
        </item>
        <item>
+        <widget class="QPushButton" name="selectColorButton">
+         <property name="focusPolicy">
+          <enum>Qt::NoFocus</enum>
+         </property>
+         <property name="text">
+          <string>Set Color</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QPushButton" name="filterButton">
          <property name="focusPolicy">
           <enum>Qt::NoFocus</enum>


### PR DESCRIPTION
# What?

This contribution solves #56 .

The contribution is about parsing the output of the logging and show it based on the color selected when creating the filter.

To create a filter
- Add a new text in the filterbox
- Click on `Set Color` and a color-picker will be open with a random color (see screenshot)
- Select your preferred color
- Click on `Filter`

![image](https://user-images.githubusercontent.com/1688725/78508849-4aa8f380-778a-11ea-9fc6-ff53e72f6a75.png)

# Example

The following example, contains two filters (the ID of the device has been removed):
![image](https://user-images.githubusercontent.com/1688725/78508596-53002f00-7788-11ea-9083-6af5f8d70792.png)
