### PR TITLE
Feature: Local & Remote filters

### DIFF
--- a/src/showbootlog.cpp
+++ b/src/showbootlog.cpp
@@ -31,6 +31,8 @@
 #include <QRegularExpression>
 #include <QCompleter>
 #include <QThread>
+#include <QColorDialog>
+#include <QRandomGenerator>
 
 ShowBootLog::ShowBootLog(QWidget *parent) :
     QDialog(parent),
@@ -111,6 +113,7 @@ void ShowBootLog::updateBootLog(bool keepIdentifiers)
         // Reset all previously accepted but also read identifiers   (clear the filter but also do a full reload!)
         this->allIdentifiers.clear();
         this->acceptedIdentifiers.clear();
+        this->acceptedIdentifiersColors.clear();
         identifierFlags = "";
 
         // Also reset the UI parts
@@ -182,8 +185,11 @@ void ShowBootLog::updateBootLog(bool keepIdentifiers)
 
 void ShowBootLog::acceptIdentifier(void){
     this->acceptedIdentifiers.insert(ui->identifiersLineEdit->text());
+    this->acceptedIdentifiersColors.insert(ui->identifiersLineEdit->text(), ui->identifiersLineEdit->palette().color(QPalette::Base));
     updateBootLog(true);
     ui->identifiersLineEdit->clear();
+    QPalette palette(QPalette::Base, Qt::white);
+    ui->identifiersLineEdit->setPalette(palette);
     ui->identifiersLineEdit->setFocus();
 }
 
@@ -191,7 +197,39 @@ void ShowBootLog::acceptIdentifier(void){
 void ShowBootLog::appendToBootLog(QString readString)
 {
     // Append string to the UI and increment byte counter
-    ui->plainTextEdit->appendPlainText(readString);
+    QStringList readStringLines = readString.split("\n");
+    QTextCharFormat defaultFormat, format;
+    QColor defaultColor, color;
+    bool found;
+    for ( const auto& line : readStringLines  )
+    {
+        // Let's find if regex apply for the current line
+        found = false;
+        for(const auto& identifier : this->acceptedIdentifiers){
+            QRegularExpression re(identifier);
+            QRegularExpressionMatch match = re.match(line);
+            found = match.hasMatch();
+            if(found)
+            {
+                color = this->acceptedIdentifiersColors.value(identifier);
+                break;
+            }
+        }
+        if(found)
+        {
+            format = ui->plainTextEdit->currentCharFormat();
+            defaultFormat = format;
+            format.setBackground(QBrush(color));
+            ui->plainTextEdit->setCurrentCharFormat(format);
+            ui->plainTextEdit->appendPlainText(line);
+            ui->plainTextEdit->setCurrentCharFormat(defaultFormat);
+        }
+        else
+        {
+            ui->plainTextEdit->appendPlainText(line);
+        }
+
+    }
     numberOfBytesRead += readString.size();
     ui->plainTextEdit->ensureCursorVisible();
 
@@ -268,7 +306,8 @@ void ShowBootLog::on_filterButton_clicked()
 {
     acceptIdentifier();
     ui->identifiersLineEdit->clear();
-
+    QPalette palette(QPalette::Base, Qt::white);
+    ui->identifiersLineEdit->setPalette(palette);
     updateBootLog(true);
 }
 
@@ -376,7 +415,10 @@ void ShowBootLog::on_clearButton_clicked()
 {
     ui->acceptedIdentifierLabel->setText("");
     ui->identifiersLineEdit->clear();
+    QPalette palette(QPalette::Base, Qt::white);
+    ui->identifiersLineEdit->setPalette(palette);
     this->acceptedIdentifiers.clear();
+    this->acceptedIdentifiersColors.clear();
     updateBootLog(false);
 }
 
@@ -401,3 +443,15 @@ void ShowBootLog::on_exportSelectionButton_clicked()
     writeToExportFile(fileName, selection.toLocal8Bit().data());
 }
 
+void ShowBootLog::on_selectColorButton_clicked()
+{
+    QColor color = QColorDialog::getColor(QColor::fromRgb(QRandomGenerator::global()->generate()), this );
+    QPalette palette;
+    palette.setColor(QPalette::Base, color);
+    if( color.isValid() )
+    {
+      qDebug() << "Color Choosen : " << color.name();
+      ui->identifiersLineEdit->setPalette(palette);
+    }
+
+}

--- a/src/showbootlog.cpp
+++ b/src/showbootlog.cpp
@@ -277,7 +277,7 @@ void ShowBootLog::appendLineWithFilterStyle(QString line)
     }
     else
     {
-        format.setForeground(QBrush(QColorConstants::LightGray));
+        format.setForeground(QBrush(QColor("LightGray")));
     }
     ui->plainTextEdit->setCurrentCharFormat(format);
     ui->plainTextEdit->appendPlainText(line);

--- a/src/showbootlog.h
+++ b/src/showbootlog.h
@@ -64,7 +64,9 @@ private slots:
 
 	void on_exportSelectionButton_clicked();
 
-	void on_horizontalSlider_valueChanged(int value);
+    void on_horizontalSlider_valueChanged(int value);
+
+    void on_selectColorButton_clicked();
 
 private:
 	void updateBootLog(bool keepIdentifiers=false);
@@ -83,8 +85,9 @@ private:
 	// Internal display variables
 	int numberOfBytesRead=0;
 	QString identifierFlags="";
-	QSet<QString> allIdentifiers;
-	QSet<QString> acceptedIdentifiers;
+    QSet<QString> allIdentifiers;
+    QSet<QString> acceptedIdentifiers;
+    QMap<QString, QColor> acceptedIdentifiersColors;
 
 	void execute_find(QRegExp regexp, QTextDocument::FindFlags findFlags);
 	void execute_find(QString string, QTextDocument::FindFlags findFlags);

--- a/src/showbootlog.h
+++ b/src/showbootlog.h
@@ -42,6 +42,8 @@ private slots:
 
 	void on_untilDateTimeEdit_dateTimeChanged();
 
+    void on_remoteFilterCheckBox_clicked();
+
 	void on_horizontalSlider_sliderMoved(int position);
 
 	void appendToBootLog(QString readString);
@@ -70,6 +72,8 @@ private slots:
 
 private:
 	void updateBootLog(bool keepIdentifiers=false);
+
+    void appendLineWithFilterStyle(QString line);
 
 	Ui::ShowBootLog *ui;
 	Connection *connection;

--- a/ui/showbootlog.ui
+++ b/ui/showbootlog.ui
@@ -264,6 +264,16 @@
         </widget>
        </item>
        <item>
+        <widget class="QCheckBox" name="remoteFilterCheckBox">
+         <property name="text">
+          <string>Remote Filter</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QPushButton" name="clearButton">
          <property name="focusPolicy">
           <enum>Qt::NoFocus</enum>

--- a/ui/showbootlog.ui
+++ b/ui/showbootlog.ui
@@ -244,6 +244,16 @@
         </widget>
        </item>
        <item>
+        <widget class="QPushButton" name="selectColorButton">
+         <property name="focusPolicy">
+          <enum>Qt::NoFocus</enum>
+         </property>
+         <property name="text">
+          <string>Set Color</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QPushButton" name="filterButton">
          <property name="focusPolicy">
           <enum>Qt::NoFocus</enum>


### PR DESCRIPTION
# What? 

This contribution fixex #59 

The contribution includes
- A new checkbox to enable the filtering remotely or in the client side
- The modification of the non-matching logging to `light-gray` 
- A refactor of #58 

# Result

In case of having the remote filter enabled, the filter is made in remote

![image](https://user-images.githubusercontent.com/1688725/78547100-cd6b9600-77fe-11ea-9883-353848a962d1.png)

If in turn, thhe `remote filter` is disabled, the filter is made locally and the non-matching lines are displayed in gray

![image](https://user-images.githubusercontent.com/1688725/78547197-f8ee8080-77fe-11ea-83a3-a8b34922cb98.png)
