### PR TITLE
Feature: Enable some connection indicator

### DIFF
--- a/src/remote.cpp
+++ b/src/remote.cpp
@@ -49,7 +49,7 @@ Remote::Remote(QObject *qObject, SSHConnectionSettings *sshSettings)
     bar->setTextVisible(false);
     connectingIndication->setBar(bar);
     connectingIndication->setWindowTitle("Connecting");
-    connectingIndication->setLabelText("Establishing the connection with" + QString::fromUtf8(sshSettings->getHostname()) + ". Please wait...");
+    connectingIndication->setLabelText("Establishing the connection with " + QString::fromUtf8(sshSettings->getHostname()) + ". Please wait...");
     connectingIndication->setCancelButton(nullptr);
     connectingIndication->setRange(0, 0);
     connectingIndication->setWindowModality(Qt::WindowModal);


### PR DESCRIPTION
# What? 

This contribution fixes #61

The contribution enables some animation to indicate that the connection is being established

![image](https://user-images.githubusercontent.com/1688725/78833240-d621bf00-79ec-11ea-9aed-781a7c0a95b2.png)

Moreover:
- The `connect` has been moved to a separated thread to avoid the `hanged` appearance of the application (it remains frozen)
- The signature of `void _custom_usleep(int sleepMs)` has been replaced to void _custom_usleep(int sleepUs) which is what makes sense
