### PR TITLE
Fix deb compatibility with Debian

### DIFF
--- a/packaging/deb/control
+++ b/packaging/deb/control
@@ -3,6 +3,6 @@ Version: 0.6.3-1
 Section: admin
 Priority: optional
 Architecture: amd64
-Depends: libssh (>= 0.8.7), qtbase5-dev (>= 5.5.1)
+Depends: libssh (>= 0.8.7) | libssh-4 (>= 0.8.7), qtbase5-dev (>= 5.5.1)
 Maintainer: Patrick Eigensatz <patrick.eigensatz@gmail.com>
 Description: A Qt-based Graphical User Interface for systemd's journalctl command


### PR DESCRIPTION
In Debian, the _libssh_ package does not exist : it's named _libssh-4_. This PR just fix the dependency declared in control file.

**Note:** I try to build and install the resulting package on my Debian Stable and it's work great.