### PR TITLE
Fix /usr/share files installation path in deb package

### DIFF
--- a/packaging/deb/build_deb.sh
+++ b/packaging/deb/build_deb.sh
@@ -10,7 +10,7 @@ QT_SELECT=qt5 qmake /source/qjournalctl.pro -r -spec linux-g++ CONFIG+=release
 make -j$(nproc)
 
 # Move required files
-cp -r /source/packaging/files "$OUT/"
+cp -r /source/packaging/files/ "$OUT/"
 mkdir -p "$OUT/usr/bin"
 mv qjournalctl "$OUT/usr/bin"
 

--- a/packaging/deb/control
+++ b/packaging/deb/control
@@ -3,6 +3,6 @@ Version: 0.6.3-1
 Section: admin
 Priority: optional
 Architecture: amd64
-Depends: libssh (>= 0.8.7), qtbase5-dev (>= 5.5.1)
+Depends: libssh (>= 0.8.7) | libssh-4 (>= 0.8.7), qtbase5-dev (>= 5.5.1)
 Maintainer: Patrick Eigensatz <patrick.eigensatz@gmail.com>
 Description: A Qt-based Graphical User Interface for systemd's journalctl command


### PR DESCRIPTION
Currently, the debian package create a _/files/usr/share_ directory instead of _/usr/share_. It's due to a missing slash in _buid_deb.sh_ file.