### PR TITLE
[Feature] Add --output=verbose option to ShowBootLog

### DIFF
--- a/src/showbootlog.cpp
+++ b/src/showbootlog.cpp
@@ -149,6 +149,9 @@ void ShowBootLog::updateBootLog(bool keepIdentifiers)
         untilStr = " --until \"" + ui->untilDateTimeEdit->dateTime().toString("yyyy-MM-dd hh:mm:00") + "\"";
     }
 
+    QString verbose = "";
+    if(verboseflag)
+        verbose=" --output=verbose -x ";
 
     QString command = "";
     if(this->completeJournal){
@@ -160,6 +163,8 @@ void ShowBootLog::updateBootLog(bool keepIdentifiers)
             command = "journalctl -q -a -p " + QString::number(maxPriority) + " -b " + bootid + sinceStr + untilStr;
         }
     }
+
+    command += verbose;
 
     if(this->reverse){
         command = command + " -r";
@@ -410,5 +415,13 @@ void ShowBootLog::on_exportSelectionButton_clicked()
     QString fileName = QFileDialog::getSaveFileName(this, "Export selected journal entries");
 
     writeToExportFile(fileName, selection.toLocal8Bit().data());
+}
+
+
+
+void ShowBootLog::on_verboseCheckBox_stateChanged(int arg1)
+{
+    verboseflag = arg1;
+    updateBootLog(false);
 }
 

--- a/src/showbootlog.h
+++ b/src/showbootlog.h
@@ -66,6 +66,8 @@ private slots:
 
     void on_horizontalSlider_valueChanged(int value);
 
+    void on_verboseCheckBox_stateChanged(int arg1);
+
 private:
     void updateBootLog(bool keepIdentifiers=false);
 
@@ -75,6 +77,7 @@ private:
     // Only journalctl options
     QString bootid;
     bool sinceFlag=false, untilFlag=false;
+    bool verboseflag=false;
     bool completeJournal=false;
     bool realtime=false;
     bool reverse=false;

--- a/ui/showbootlog.ui
+++ b/ui/showbootlog.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>1164</width>
-    <height>632</height>
+    <height>675</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -206,6 +206,13 @@
         </widget>
        </item>
       </layout>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="verboseCheckBox">
+       <property name="text">
+        <string>Verbose</string>
+       </property>
+      </widget>
      </item>
      <item>
       <widget class="QLabel" name="label_12">


### PR DESCRIPTION
Add verbose checkbox to showbootlog. Checkbox adds  **--output=verbose -x** options to _journalctl_ command line.