### PR TITLE
Allow changing installation prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ to build and install libssh yourself (< 2 minutes!)
 3. Run `make -j$(nproc)` to compile qjournalctl
 4. Run `sudo make install`  
 
+Step 4 installs QJournalctl under `/usr`. If this is incorrect the path can be changed by defining
+`PREFIX` environment variable before running `autogen.sh`, for example:
+
+```bash
+PREFIX=/usr/local ./autogen.sh
+```
 
 
 ## QJournalctl for macOS

--- a/autogen.sh
+++ b/autogen.sh
@@ -19,5 +19,5 @@ if [ "$(uname -s)" = "Darwin" ]; then
   QMAKE_SPEC="macx-clang"
 fi
 
-QT_SELECT=qt5 $QMAKE_BIN qjournalctl.pro -r -spec $QMAKE_SPEC CONFIG+=release
+QT_SELECT=qt5 $QMAKE_BIN qjournalctl.pro -r -spec $QMAKE_SPEC CONFIG+=release "PREFIX=\"$PREFIX\""
 

--- a/qjournalctl.pro
+++ b/qjournalctl.pro
@@ -19,6 +19,9 @@ CONFIG += c++11
 # qmake qjournalctl.pro CONFIG+=release CONFIG+=x86_64 VCPKG_FOLDER=%VCPKG_INSTALL_FOLDER%
 !defined(VCPKG_FOLDER, var):VCPKG_FOLDER = $$_PRO_FILE_PWD_\vcpkg
 
+# Use /usr as installation prefix if not provided
+isEmpty(PREFIX):PREFIX = /usr
+
 SOURCES += src/main.cpp\
 	src/connectiondialog.cpp \
 	src/connection.cpp \
@@ -64,14 +67,14 @@ RESOURCES += \
 # This prevents qmake from failing when trying to install
 # the desktop environment files
 QMAKE_STRIP = echo
-target.path = /usr/bin
+target.path = $$PREFIX/bin
 
 # Desktop environment files
-desktop-file.path = /usr/share/applications
+desktop-file.path = $$PREFIX/share/applications
 desktop-file.files += ui/qjournalctl.desktop
-desktop-icon.path = /usr/share/pixmaps
+desktop-icon.path = $$PREFIX/share/pixmaps
 desktop-icon.files += ui/qjournalctl.png
-metainfo-file.path = /usr/share/metainfo
+metainfo-file.path = $$PREFIX/share/metainfo
 metainfo-file.files += qjournalctl.appdata.xml
 
 INSTALLS += target desktop-file desktop-icon metainfo-file


### PR DESCRIPTION
This PR makes it possible to change where `make install` installs files.

This is useful in NixOS where the correct installation path is for example `/nix/store/y0r97v3g7amkaw0rcvkmxnj6al02q064-qjournalctl-0.6.4` instead of `/usr`.

Qjournalctl's package definition in nixpkgs modifies `qjournalctl.pro`, replacing `/usr` with correct path here:
https://github.com/NixOS/nixpkgs/blob/bf3287dac860542719fe7554e21e686108716879/pkgs/applications/system/qjournalctl/default.nix#L24

However, with this change that patching phase is not needed. Package's configure phase is already calling `qmake` with `PREFIX` provided as argument. It is just matter of using the variable in the project file. This makes it easier to hack qjournalctl's code in NixOS as the project file does not need to be changed.

Modified also `autogen.sh` and added readme instructions in case defining PREFIX is useful outside of NixOS usage.